### PR TITLE
add API to remove controllers and their routes from an existing router

### DIFF
--- a/src/main/java/tech/greenfield/vertx/irked/Controller.java
+++ b/src/main/java/tech/greenfield/vertx/irked/Controller.java
@@ -16,6 +16,8 @@ public class Controller {
 	protected interface RawVertxHandler extends Handler<RoutingContext> {}
 	protected interface WebHandler extends Handler<Request> {}
 	protected interface MessageHandler extends Handler<WebSocketMessage> {}
+
+	private List<RouteConfiguration> routes;
 	
 	/**
 	 * Controller implementations should override this to generate local
@@ -40,7 +42,7 @@ public class Controller {
 			out.add(RouteConfiguration.wrap(this, f));
 		for (Method m : getClass().getDeclaredMethods())
 			out.add(RouteConfiguration.wrap(this, m));
-		return out.stream().filter(RouteConfiguration::isValid).collect(Collectors.toList());
+		return routes = out.stream().filter(RouteConfiguration::isValid).collect(Collectors.toList());
 	}
 
 	/**
@@ -80,5 +82,9 @@ public class Controller {
 			throw new RuntimeException("Error accessing field " + field + ": " + e, e);
 		}
 	}
-
+	
+	public void remove() {
+		routes.forEach(RouteConfiguration::remove);
+	}
+	
 }

--- a/src/main/java/tech/greenfield/vertx/irked/RouteConfiguration.java
+++ b/src/main/java/tech/greenfield/vertx/irked/RouteConfiguration.java
@@ -102,6 +102,9 @@ public abstract class RouteConfiguration {
 	}
 	
 	Pattern trailingSlashRemover = Pattern.compile("./$");
+
+	private List<Route> routes = new ArrayList<>();
+	
 	public <T extends Annotation> Stream<String> pathsForAnnotation(String prefix, Class<T> anot) {
 		return Arrays.stream(uriForAnnotation(anot))
 				.filter(s -> Objects.nonNull(s))
@@ -121,6 +124,7 @@ public abstract class RouteConfiguration {
 				r.failureHandler(getHandler(requestWrapper));
 			else
 				r.handler(getHandler(requestWrapper));
+			routes.add(r);
 			out.add(r.toString());
 		}
 		return out;
@@ -159,5 +163,9 @@ public abstract class RouteConfiguration {
 		} catch (IllegalAccessException e) {
 			throw new InvalidRouteConfiguration("Illegal access error while trying to configure " + this);
 		}
+	}
+	
+	void remove() {
+		routes.forEach(Route::remove);
 	}
 }

--- a/src/main/java/tech/greenfield/vertx/irked/Router.java
+++ b/src/main/java/tech/greenfield/vertx/irked/Router.java
@@ -44,6 +44,11 @@ public class Router implements io.vertx.ext.web.Router{
 		return this;
 	}
 	
+	public Router remove(Controller api) {
+		api.remove();
+		return this;
+	}
+	
 	public Router configReport() {
 		routePaths.stream().sorted().forEach(p -> System.out.println(p));
 		return this;


### PR DESCRIPTION
Support dynamically removing controllers as per issue #2.

Currently supports only removing controllers that were already configured on a router:

```
Future<HttpServer> async = Future.future();
Controller controller = new com.example.api.Root();
Router router = Irked.router(getVertx()).with(controller);
vertx.createHttpServer()
		.requestHandler(router::accept)
		.listen(port, async);

// later ...
router.remove(controller);
// or 
controller.remove();
```

This, on the other hand, will not work:

```
router.remove(new com.example.api.Root());
```